### PR TITLE
Towny and Animal Handler updates

### DIFF
--- a/com/smartaleq/bukkit/dwarfcraft/DCTowny.java
+++ b/com/smartaleq/bukkit/dwarfcraft/DCTowny.java
@@ -43,7 +43,7 @@ class DCTowny extends TownyPlayerListener {
 
 		try {
 			int cost = blockCost * selection.size();
-			if (TownySettings.isUsingIConomy() && !owner.canPay(cost))
+			if (TownySettings.isUsingIConomy() && !owner.canPayFromHoldings(cost))
 				throw new TownyException("Town cannot afford to claim " + selection.size() + " town blocks costing " + cost + TownyIConomyObject.getIConomyCurrency());
 		} catch (IConomyException e1) {
 			throw new TownyException("Iconomy Error");

--- a/com/smartaleq/bukkit/dwarfcraft/events/DCEntityListener.java
+++ b/com/smartaleq/bukkit/dwarfcraft/events/DCEntityListener.java
@@ -339,6 +339,8 @@ public class DCEntityListener extends EntityListener {
 									deadThing.getClass().getSimpleName(), effect.getId(), output.getAmount(), 
 									output.getType().name()));
 							}
+                                                        if(deadThing instanceof CraftSheep)
+                                                                output.setDurability((short) ((CraftSheep)deadThing).getColor().ordinal());
 							if (output.getAmount() > 0)
 								items.add(output);
 						}


### PR DESCRIPTION
canPay(cost) no longer exists, its canPayFromHoldings(cost). Untested as to if it has the same functionality.

Animal Handler can now drop colored wool from a correspondingly colored sheep. 
((org.bukkit.material.Wool)output.getData()).setColor(((CraftSheep)deadThing).getColor());
wasnt working properly, so I had to resort to the durability method instead.
